### PR TITLE
Dev 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,9 @@ System specifications used for development and testing:
    ```
 
 2. Install muddy: (for MUD file generation)
-   * Follow instructions at: https://github.com/upaulnight/muddy
+   * Follow instructions at: https://github.com/usnistgov/muddy
    * IMPORTANT:
-      * Latest verified compatible commit: c498ea9b159c5881ffbaacc2e4064c2cf9081775 (2021-03-12)
+      * Latest verified compatible commit: 1434c380cdd49077b273c9aafdb2c7e0ef733636 (2021-04-05)
       * Verified to work when muddy is installed within the root directory of the MUD-PD repository
 
 ## Running MUD-PD

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ System specifications used for development and testing:
      ```sh
      shell> sudo apt-get install git
      ```
-1. Python 3.8.4+
+1. Python 3.8.4-3.9.10:
 
    * Check version
      ```sh
@@ -90,16 +90,16 @@ System specifications used for development and testing:
      You can also try the following commands
      * macOS:
      ```sh
-     shell> brew install python3
+     brew install python3
      ```
 
      * Linux
      ```sh
-     shell> sudo apt-get install python3.8
+     sudo apt-get install python3.8
      ```
      or
      ```sh
-     shell> sudo apt-get install python3.9
+     sudo apt-get install python3.9
      ```
 
 2. MySQL
@@ -227,6 +227,8 @@ necessarily between both</li>
     a. On Ubuntu, scaling may not work correctly for some buttons. Try a different scale percentage.
    
     b. On macOS, Dark Mode may modify the colors of some text and background. Try selecting Light Mode.
+    
+    c. On macOS, Python version 3.10+ causes the background colors of the tool to go dark. Try downgrading to Python version 3.9.
 
 ## Contact Us
 These programs were developed by Paul Watrobski and Joshua Klosterman. Questions and bug reports may be directed to

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-mysql-connector-python >= 8.0.22, == 8.0.*
+mysql-connector-python >= 8.0.26, == 8.0.*
 pyshark >= 0.4.3, == 0.4.*
-requests >= 2.25.1, == 2.25.*
+requests >= 2.26.0, == 2.26.*
 overload >= 1.1, == 1.*
 IPy ~= 1.0
 getversion ~= 1.0.2
-Pillow ~= 8.1.2
+Pillow ~= 8.3.2


### PR DESCRIPTION
Deleted ```shell > "commands" ``` to make it easier to copy and paste command directly. Python 3.10 is not compatible with the tool. I also want to add a section about wireshark files being too big or a FAQ page.